### PR TITLE
Don't try to initialize partitions if there is no MBR on the device.

### DIFF
--- a/app/src/main/java/com/github/mjdev/libaums/usbfileman/MainActivity.java
+++ b/app/src/main/java/com/github/mjdev/libaums/usbfileman/MainActivity.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import android.Manifest;
@@ -86,6 +87,7 @@ import com.github.mjdev.libaums.fs.FileSystemFactory;
 import com.github.mjdev.libaums.fs.UsbFile;
 import com.github.mjdev.libaums.fs.UsbFileInputStream;
 import com.github.mjdev.libaums.fs.UsbFileStreamFactory;
+import com.github.mjdev.libaums.partition.Partition;
 import com.github.mjdev.libaums.server.http.UsbFileHttpServerService;
 import com.github.mjdev.libaums.server.http.server.AsyncHttpServer;
 
@@ -761,7 +763,11 @@ public class MainActivity extends AppCompatActivity implements OnItemClickListen
             massStorageDevices[currentDevice].init();
 
 			// we always use the first partition of the device
-			currentFs = massStorageDevices[currentDevice].getPartitions().get(0).getFileSystem();
+            final List<Partition> partitions = massStorageDevices[currentDevice].getPartitions();
+            if (partitions.isEmpty()) {
+                throw new IOException("device has no partitions.");
+            }
+            currentFs = partitions.get(0).getFileSystem();
 			Log.d(TAG, "Capacity: " + currentFs.getCapacity());
 			Log.d(TAG, "Occupied Space: " + currentFs.getOccupiedSpace());
 			Log.d(TAG, "Free Space: " + currentFs.getFreeSpace());

--- a/libaums/src/main/java/com/github/mjdev/libaums/UsbMassStorageDevice.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/UsbMassStorageDevice.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.hardware.usb.UsbConstants;
 import android.hardware.usb.UsbDevice;
@@ -30,7 +29,6 @@ import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
-import android.os.Build;
 import android.util.Log;
 
 import com.github.mjdev.libaums.driver.BlockDeviceDriver;
@@ -230,7 +228,9 @@ public class UsbMassStorageDevice {
 		blockDevice = BlockDeviceDriverFactory.createBlockDevice(communication);
 		blockDevice.init();
 		partitionTable = PartitionTableFactory.createPartitionTable(blockDevice);
-		initPartitions();
+		if (partitionTable != null) {
+			initPartitions();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Catches a `NullPointerException`.