### PR TITLE
Expose block device in API so it can be written to directly

### DIFF
--- a/libaums/src/main/java/com/github/mjdev/libaums/UsbMassStorageDevice.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/UsbMassStorageDevice.java
@@ -290,4 +290,13 @@ public class UsbMassStorageDevice {
 	public UsbDevice getUsbDevice() {
 		return usbDevice;
 	}
+
+	/**
+	 * Returns the block device interface for this device.
+	 *
+	 * @return The BlockDeviceDriver implementation
+	 */
+	public BlockDeviceDriver getBlockDevice() {
+		return blockDevice;
+	}
 }

--- a/libaums/src/main/java/com/github/mjdev/libaums/UsbMassStorageDevice.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/UsbMassStorageDevice.java
@@ -293,6 +293,9 @@ public class UsbMassStorageDevice {
 
 	/**
 	 * Returns the block device interface for this device.
+	 * 
+	 * Only use this if you know what you are doing, for a interacting (listing/reading/writing files)
+	 * with a pen drive this is usually not needed
 	 *
 	 * @return The BlockDeviceDriver implementation
 	 */


### PR DESCRIPTION
My main use for this library is to write directly to the underlying USB drive regardless of the partition table (actually in my case there isn't supposed to be any).

This adds a getter for blockDevice