### PR TITLE
Add getSize() method to BlockDeviceDriver interface and implement it

### DIFF
--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/BlockDeviceDriver.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/BlockDeviceDriver.java
@@ -84,4 +84,12 @@ public interface BlockDeviceDriver {
 	 * @return The block size in bytes, mostly 512 bytes.
 	 */
 	public int getBlockSize();
+
+	/**
+	 * Returns the size of the block device in blocks. That means that the
+	 * total device size is `getSize() * getBlockSize()` bytes.
+	 *
+	 * @return The size of the device in blocks
+	 */
+	public int getSize();
 }

--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/ByteBlockDevice.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/ByteBlockDevice.java
@@ -122,4 +122,9 @@ public class ByteBlockDevice implements BlockDeviceDriver {
     public int getBlockSize() {
         return targetBlockDevice.getBlockSize();
     }
+
+    @Override
+    public int getSize() {
+        return targetBlockDevice.getSize();
+    }
 } 

--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/file/FileBlockDeviceDriver.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/file/FileBlockDeviceDriver.java
@@ -20,10 +20,12 @@ public class FileBlockDeviceDriver implements BlockDeviceDriver {
     private RandomAccessFile file;
     private int blockSize;
     private int byteOffset;
+    private int blockDevSize;
 
     public FileBlockDeviceDriver(File file, int blockSize, int byteOffset) throws FileNotFoundException {
         this.file = new RandomAccessFile(file, "rw");
         this.blockSize = blockSize;
+        this.blockDevSize = (int) (file.length() / blockSize);
         this.byteOffset = byteOffset;
     }
 
@@ -76,5 +78,10 @@ public class FileBlockDeviceDriver implements BlockDeviceDriver {
     @Override
     public int getBlockSize() {
         return blockSize;
+    }
+
+    @Override
+    public int getSize() {
+        return blockDevSize;
     }
 }

--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/ScsiBlockDevice.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/ScsiBlockDevice.java
@@ -237,4 +237,9 @@ public class ScsiBlockDevice implements BlockDeviceDriver {
 	public int getBlockSize() {
 		return blockSize;
 	}
+
+	@Override
+	public int getSize() {
+		return lastBlockAddress;
+	}
 }


### PR DESCRIPTION
Adds a getSize method to all block device drivers that returns the size of that block device, in blocks.