### PR TITLE
ByteBlockDevice.getBlockSize() should return 1

### DIFF
--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/ByteBlockDevice.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/ByteBlockDevice.java
@@ -120,6 +120,6 @@ public class ByteBlockDevice implements BlockDeviceDriver {
 
     @Override
     public int getBlockSize() {
-        return targetBlockDevice.getBlockSize();
+        return 1;
     }
 } 


### PR DESCRIPTION
Closes #152 