### PR TITLE
Ensure ScsiBlockDevice gives up trying after max attempts

### DIFF
--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/ScsiBlockDevice.kt
@@ -146,7 +146,7 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
 
                 // Try alternately to clear halt and reset device until something happens
                 when {
-                    i == MAX_RECOVERY_ATTEMPTS -> {
+                    i == MAX_RECOVERY_ATTEMPTS - 1 -> {
                         Log.d(TAG, "Giving up")
                         throw e
                     }


### PR DESCRIPTION
#237:

> ```
>  java.lang.IllegalStateException: This should never happen.
>         at com.github.mjdev.libaums.driver.scsi.ScsiBlockDevice.transferCommand(ScsiBlockDevice.kt:170)
>         at com.github.mjdev.libaums.driver.scsi.ScsiBlockDevice.write(ScsiBlockDevice.kt:271)
>         at com.github.mjdev.libaums.driver.ByteBlockDevice.write(ByteBlockDevice.kt:104)
>         at com.github.mjdev.libaums.fs.fat32.FsInfoStructure.write(FsInfoStructure.kt:126)
>         at com.github.mjdev.libaums.fs.fat32.FAT.alloc$libaums_release(FAT.kt:266)
>         at com.github.mjdev.libaums.fs.fat32.FatDirectory.createFile(FatDirectory.kt:313)
>         at com.github.mjdev.libaums.fs.fat32.FatDirectory.createFile(FatDirectory.kt:36)
>         ....
> ```