### PR TITLE
Fixes for QEMU

### DIFF
--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/ScsiBlockDevice.kt
@@ -199,6 +199,10 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
         }
 
         val transferLength = command.dCbwDataTransferLength
+        inBuffer.apply {
+            limit(position() + transferLength)
+        }
+
         var read = 0
         if (transferLength > 0) {
 

--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/ScsiBlockDevice.kt
@@ -49,7 +49,7 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
     private val readCommand = ScsiRead10(lun=lun)
     private val csw = CommandStatusWrapper()
 
-    private var cbwTagCounter = 0
+    private var cbwTagCounter = 1
 
     /**
      * The size of the block device, in blocks of [blockSize] bytes,

--- a/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/commands/ScsiReadCapacity.kt
+++ b/libaums/src/main/java/com/github/mjdev/libaums/driver/scsi/commands/ScsiReadCapacity.kt
@@ -38,7 +38,7 @@ class ScsiReadCapacity(lun: Byte) : CommandBlockWrapper(RESPONSE_LENGTH, Directi
     companion object {
 
         private const val RESPONSE_LENGTH = 0x8
-        private const val LENGTH: Byte = 0x10
+        private const val LENGTH: Byte = 10
         private const val OPCODE: Byte = 0x25
     }
 


### PR DESCRIPTION
I've been trying to get libaums to work on QEMU and this is a thing I spotted, that is `READ_CAPACITY(10)` is 10 bytes, not 0x10 bytes.

Other differences I noticed from both Linux and the other proprietary app I've been analyzing is that they both start with `cbwTagCounter` at 1, not 0 as libaums did. I haven't read the USB MSD protocol specification so I don't know if that's an issue, but even if the tag can be anything I'd say that if the most widely used platform count like MATLAB counts, let's do MATLAB too. (I'll send this patch tomorrow).

Anyway this is still WIP since I just built QEMU from latest git and enabled debugging for its emulated USB storage and... it works perfectly 🤷‍♂️

I'm still very perplexed though: in my local repo I fixed the read capacity size and I made the tag counter start from 1. I compared the messages exchanged when the emulated drive is controlled by Linux, the proprietary app and Libaums. With my patches and when running on QEMU stable, the messages from all of them are **exactly** the same. Yet, when linux or the other app send READ_CAPACITY, the drive replies. When libaums does, it says no.

This means I'll also be building again QEMU stable with emulated MSD debug enabled, I'll see what happens with that one.