### PR TITLE
Provide constants file for gradle dependencies

### DIFF
--- a/androidtests/build.gradle
+++ b/androidtests/build.gradle
@@ -1,19 +1,20 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply from: "../constants.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    compileSdkVersion project.ext.compileSdkVersion
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
+        versionCode project.ext.versionCode
+        versionName project.ext.versionName
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        testInstrumentationRunnerArguments.package = 'me.jahnen.libaums.androidtests'
+        testInstrumentationRunner project.ext.testInstrumentationRunner
+        testInstrumentationRunnerArguments.package = "me.jahnen.libaums.androidtests"
 
         consumerProguardFiles "consumer-rules.pro"
     }
@@ -21,28 +22,26 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
         debug {
             minifyEnabled false
         }
     }
 
-    useLibrary 'android.test.runner'
-    useLibrary 'android.test.base'
-    useLibrary 'android.test.mock'
+    useLibrary "android.test.runner"
+    useLibrary "android.test.base"
+    useLibrary "android.test.mock"
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "androidx.core:core-ktx:$coreKtx"
 
-    androidTestImplementation 'androidx.test:core:1.3.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'androidx.test:rules:1.3.0'
-    androidTestImplementation project(':javafs')
-    androidTestImplementation project(':libusbcommunication')
+    androidTestImplementation "androidx.test:core:$testCoreVersion"
+    androidTestImplementation "androidx.test.ext:junit:$testExtJunitVersion"
+    androidTestImplementation "androidx.test:runner:$testRunnerVersion"
+    androidTestImplementation "androidx.test:rules:$testRulesVersion"
+    androidTestImplementation project(":javafs")
+    androidTestImplementation project(":libusbcommunication")
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,18 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply from: "../constants.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    compileSdkVersion project.ext.compileSdkVersion
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        applicationId "com.github.mjdev.usbfileman"
-        minSdkVersion 16
-        targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
+        applicationId project.ext.applicationId
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
+        versionCode project.ext.versionCode
+        versionName project.ext.versionName
     }
     buildTypes {
         release {
@@ -26,13 +27,11 @@ android {
 }
 
 dependencies {
-    api fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'junit:junit:4.12'
-    api 'androidx.appcompat:appcompat:1.0.0-beta01'
-    api 'com.google.android.material:material:1.0.0-beta01'
-    api project(':libaums')
-    api project(':httpserver')
-    api project(':storageprovider')
-    api project(':javafs')
-    api project(':libusbcommunication')
+    api "androidx.appcompat:appcompat:$appcompatVersion"
+    api "com.google.android.material:material:$materialVersion"
+    api project(":libaums")
+    api project(":httpserver")
+    api project(":storageprovider")
+    api project(":javafs")
+    api project(":libusbcommunication")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,73 +1,39 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    apply from: "constants.gradle"
+
     repositories {
         jcenter()
         maven {
-            url 'https://dl.bintray.com/magnusja/maven'
+            url "https://dl.bintray.com/magnusja/maven"
         }
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
-        maven { url "https://plugins.gradle.org/m2/" }
+        mavenCentral()
         google()
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
-
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-
-        classpath 'org.codehaus.groovy:groovy-all:2.4.15'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.20"
-        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0"
-
+        classpath "com.android.tools.build:gradle:$buildGradleVersion"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$gradleBintrayPluginVersion"
+        classpath "com.github.dcendents:android-maven-gradle-plugin:$androidMavenGradlePluginVersion"
+        classpath "org.codehaus.groovy:groovy-all:$groovyAllVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaGradlePluginVersion"
+        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:$jacocoPluginVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
-ext {
-    bintrayRepo = 'maven'
-
-    publishedGroupId = 'me.jahnen'
-    libraryName = 'libaums'
-
-    // artifact comes from module as well as libraryVersion
-    //artifact = 'libaums'
-
-    libraryDescription = 'Android USB mass storage library with FAT32 support.'
-
-    siteUrl = 'https://github.com/magnusja/libaums'
-    gitUrl = 'https://github.com/magnusja/libaums.git'
-
-
-    developerId = 'magnusja'
-    developerName = 'Magnus Jahnen'
-    developerEmail = 'github@mgns.tech'
-
-    licenseName = 'The Apache Software License, Version 2.0'
-    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-    allLicenses = ["Apache-2.0"]
-}
-
 allprojects {
     repositories {
         jcenter()
-        maven { url 'https://dl.bintray.com/magnusja/maven' }
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        maven { url "https://dl.bintray.com/magnusja/maven" }
+        mavenCentral()
+        google()
     }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-

--- a/constants.gradle
+++ b/constants.gradle
@@ -1,0 +1,92 @@
+/**
+ * Project dependencies constants.
+ */
+project.ext {
+
+    /////////////////////////////////////
+    // Version section
+    /////////////////////////////////////
+
+    applicationId = "com.github.mjdev.usbfileman"
+
+    versionCode = 2
+    versionName = "0.2"
+
+    versionCodeProduction = 2
+    versionNameProduction = "0.2"
+
+    /////////////////////////////////////
+    // SDK section
+    /////////////////////////////////////
+
+    compileSdkVersion = 30
+    minSdkVersion = 16
+    targetSdkVersion = 30
+    ndkVersion = "22.0.7026061"
+
+    /////////////////////////////////////
+    // Build section
+    /////////////////////////////////////
+
+    buildToolsVersion = "30.0.3"
+    buildGradleVersion = "4.1.2"
+    gradleBintrayPluginVersion = "1.8.4"
+    androidMavenGradlePluginVersion = "2.1"
+    groovyAllVersion = "2.4.15"
+    dokkaGradlePluginVersion = "1.4.20"
+    jacocoPluginVersion = "0.16.0"
+    appcompatVersion = "1.2.0"
+    materialVersion = "1.3.0"
+
+    nanohttpdVersion = "2.3.1"
+    koushikduttaAsyncVersion = "2.+"
+    annotationVersion = "1.1.0"
+
+    log4jVersion = "1.2.17"
+    loggingLog4jVersion = "1.0.3"
+    javaFsVersion = "0.1.5"
+
+    /////////////////////////////////////
+    // Kotlin section
+    /////////////////////////////////////
+
+    kotlinVersion = "1.4.30"
+    coreKtx = "1.3.2"
+
+    /////////////////////////////////////
+    // Test section
+    /////////////////////////////////////
+
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    junitVersion ="4.13.1"
+    apacheCommonsIoVersion = "1.3.2"
+    eclipsesourceMinimalJsonVersion = "0.9.4"
+    xeneiJunitContractsVersion = "0.1.7"
+    mockitoCoreVersion = "3.6.0"
+    testCoreVersion = "1.3.0"
+    testExtJunitVersion = "1.1.2"
+    testRunnerVersion = "1.3.0"
+    testRulesVersion = "1.3.0"
+
+    /////////////////////////////////////
+    // Library section
+    /////////////////////////////////////
+
+    bintrayRepo = "maven"
+
+    publishedGroupId = "me.jahnen"
+    libraryName = "libaums"
+
+    libraryDescription = "Android USB mass storage library with FAT32 support."
+
+    siteUrl = "https://github.com/magnusja/libaums"
+    gitUrl = "https://github.com/magnusja/libaums.git"
+
+    developerId = "magnusja"
+    developerName = "Magnus Jahnen"
+    developerEmail = "github@mgns.tech"
+
+    licenseName = "The Apache Software License, Version 2.0"
+    licenseUrl = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+    allLicenses = ["Apache-2.0"]
+}

--- a/httpserver/build.gradle
+++ b/httpserver/build.gradle
@@ -1,14 +1,15 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'org.jetbrains.dokka'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "org.jetbrains.dokka"
+apply from: "../constants.gradle"
 
-project.archivesBaseName = 'libaums-httpserver'
+project.archivesBaseName = "libaums-httpserver"
 
 ext {
-    artifact = 'libaums-httpserver'
-    bintrayName = 'libaums-httpserver'
-    libraryVersion = '0.5.3'
+    artifact = "libaums-httpserver"
+    bintrayName = "libaums-httpserver"
+    libraryVersion = "0.5.3"
 }
 
 configurations {
@@ -16,19 +17,19 @@ configurations {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    compileSdkVersion project.ext.compileSdkVersion
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
+        versionCode project.ext.versionCode
+        versionName project.ext.versionName
     }
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
     lintOptions {
@@ -36,25 +37,16 @@ android {
     }
 }
 
-
 dependencies {
-    api 'org.nanohttpd:nanohttpd:2.+'
-    javadocDeps 'org.nanohttpd:nanohttpd:2.+'
-
-    api 'com.koushikdutta.async:androidasync:2.+'
-
-    api fileTree(include: ['*.jar'], dir: 'libs')
-    api 'androidx.annotation:annotation:1.1.0'
-    api 'androidx.core:core:1.2.0-rc01'
-    api project(':libaums')
-    api "androidx.core:core-ktx:1.1.0"
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    javadocDeps "org.nanohttpd:nanohttpd:$nanohttpdVersion"
+    api "org.nanohttpd:nanohttpd:$nanohttpdVersion"
+    api "com.koushikdutta.async:androidasync:$koushikduttaAsyncVersion"
+    api "androidx.core:core-ktx:$coreKtx"
+    api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    api project(":libaums")
 }
 
 task bintray {
-    apply from: '../install.gradle'
-    apply from: '../bintray.gradle'
-}
-repositories {
-    mavenCentral()
+    apply from: "../install.gradle"
+    apply from: "../bintray.gradle"
 }

--- a/javafs/build.gradle
+++ b/javafs/build.gradle
@@ -1,22 +1,20 @@
-apply plugin: 'com.android.library'
+apply plugin: "com.android.library"
+apply from: "../constants.gradle"
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    compileSdkVersion project.ext.compileSdkVersion
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
+        versionCode project.ext.versionCode
+        versionName project.ext.versionName
     }
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
     lintOptions {
@@ -25,15 +23,9 @@ android {
 }
 
 dependencies {
-    api project(':libaums')
+    api project(":libaums")
 
-    api('log4j:log4j:1.2.17')
-    api('de.mindpipe.android:android-logging-log4j:1.0.3')
-    api 'com.github.magnusja:java-fs:0.1.5'
-
-    api fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0-alpha4', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
-    testImplementation 'junit:junit:4.12'
+    api "log4j:log4j:$log4jVersion"
+    api "de.mindpipe.android:android-logging-log4j:$loggingLog4jVersion"
+    api "com.github.magnusja:java-fs:$javaFsVersion"
 }

--- a/libaums/build.gradle
+++ b/libaums/build.gradle
@@ -1,13 +1,14 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'org.jetbrains.dokka'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "org.jetbrains.dokka"
 apply plugin: "com.vanniktech.android.junit.jacoco"
+apply from: "../constants.gradle"
 
 ext {
-    artifact = 'libaums'
-    bintrayName = 'libaums'
-    libraryVersion = '0.8.0'
+    artifact = "libaums"
+    bintrayName = "libaums"
+    libraryVersion = "0.8.0"
 }
 
 configurations {
@@ -19,25 +20,25 @@ junitJacoco {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    compileSdkVersion project.ext.compileSdkVersion
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 30
-        versionCode 80
-        versionName "0.8.0"
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
+        versionCode project.ext.versionCodeProduction
+        versionName project.ext.versionNameProduction
 
         externalNativeBuild {
             cmake {
-                abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+                abiFilters "arm64-v8a", "armeabi-v7a", "x86", "x86_64"
             }
         }
     }
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
 
         debug {
@@ -59,28 +60,21 @@ android {
             path "CMakeLists.txt"
         }
     }
-    ndkVersion '22.0.70260617'
+    ndkVersion project.ext.ndkVersion
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'org.apache.commons:commons-io:1.3.2'
-    testImplementation 'com.eclipsesource.minimal-json:minimal-json:0.9.4'
-    testImplementation 'org.xenei:junit-contracts:0.1.7'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.apache.commons:commons-io:$apacheCommonsIoVersion"
+    testImplementation "com.eclipsesource.minimal-json:minimal-json:$eclipsesourceMinimalJsonVersion"
+    testImplementation "org.xenei:junit-contracts:$xeneiJunitContractsVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
 
-    api 'androidx.annotation:annotation:1.1.0'
-    javadocDeps 'androidx.annotation:annotation:1.1.0'
-    api 'androidx.core:core:1.5.0-alpha05'
-    api "androidx.core:core-ktx:1.3.2"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    api "androidx.core:core-ktx:$coreKtx"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }
 
 task bintray {
-    apply from: '../install.gradle'
-    apply from: '../bintray.gradle'
+    apply from: "../install.gradle"
+    apply from: "../bintray.gradle"
 }
-repositories {
-    mavenCentral()
-}
-

--- a/libusbcommunication/build.gradle
+++ b/libusbcommunication/build.gradle
@@ -1,34 +1,34 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
-apply plugin: 'org.jetbrains.dokka'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "kotlin-android-extensions"
+apply plugin: "org.jetbrains.dokka"
+apply from: "../constants.gradle"
 
 Properties props = new Properties()
-props.load(new FileInputStream(project.rootProject.file('local.properties')))
-String libusbDir = props['libusb.dir']
+props.load(new FileInputStream(project.rootProject.file("local.properties")))
+String libusbDir = props["libusb.dir"]
 
 ext {
-    artifact = 'libaums-libusbcommunication'
-    bintrayName = 'libaums-libusbcommunication'
-    libraryVersion = '0.2'
+    artifact = "libaums-libusbcommunication"
+    bintrayName = "libaums-libusbcommunication"
+    libraryVersion = "0.2"
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion project.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 30
-        versionCode 2
-        versionName "0.2"
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
+        versionCode project.ext.versionCode
+        versionName project.ext.versionName
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles 'consumer-rules.pro'
+        consumerProguardFiles "consumer-rules.pro"
 
         externalNativeBuild {
             cmake {
                 arguments "-DLIBUSB_PATH=" + libusbDir
-                abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+                abiFilters "arm64-v8a", "armeabi-v7a", "x86", "x86_64"
             }
         }
     }
@@ -36,7 +36,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 
@@ -45,26 +45,18 @@ android {
             path "CMakeLists.txt"
         }
     }
-    ndkVersion '22.0.7026061'
+    ndkVersion project.ext.ndkVersion
 
 }
 
-
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "androidx.core:core-ktx:$coreKtx"
 
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'org.apache.commons:commons-io:1.3.2'
-    testImplementation 'com.eclipsesource.minimal-json:minimal-json:0.9.4'
-    testImplementation 'org.xenei:junit-contracts:0.1.7'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
-
-    api project(':libaums')
+    api project(":libaums")
 }
 
 task bintray {
-    apply from: '../install.gradle'
-    apply from: '../bintray.gradle'
+    apply from: "../install.gradle"
+    apply from: "../bintray.gradle"
 }

--- a/storageprovider/build.gradle
+++ b/storageprovider/build.gradle
@@ -1,11 +1,12 @@
-apply plugin: 'com.android.library'
+apply plugin: "com.android.library"
+apply from: "../constants.gradle"
 
-project.archivesBaseName = 'libaums-storageprovider'
+project.archivesBaseName = "libaums-storageprovider"
 
 ext {
-    artifact = 'libaums-storageprovider'
-    bintrayName = 'libaums-storageprovider'
-    libraryVersion = '0.5.1'
+    artifact = "libaums-storageprovider"
+    bintrayName = "libaums-storageprovider"
+    libraryVersion = "0.5.1"
 }
 
 configurations {
@@ -13,19 +14,19 @@ configurations {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.3'
+    compileSdkVersion project.ext.compileSdkVersion
+    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion project.ext.minSdkVersion
+        targetSdkVersion project.ext.targetSdkVersion
+        versionCode project.ext.versionCode
+        versionName project.ext.versionName
     }
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
     lintOptions {
@@ -34,13 +35,12 @@ android {
 }
 
 dependencies {
-    api fileTree(include: ['*.jar'], dir: 'libs')
-    api 'org.apache.commons:commons-io:1.3.2'
-    api project(':libaums')
+    api "org.apache.commons:commons-io:$apacheCommonsIoVersion"
+    api project(":libaums")
 }
 
 
 task bintray {
-    apply from: '../install.gradle'
-    apply from: '../bintray.gradle'
+    apply from: "../install.gradle"
+    apply from: "../bintray.gradle"
 }


### PR DESCRIPTION
This change introduces single constants.gradle file that contain
all versions necessary for gradle dependencies used in different
modules. The goal is to avoid copy/paste and have them controlled
in one place.
It also contain optimization inside gradle files, such as exclude
not used properties, etc ...
All tests are passed localy.