### PR TITLE
Fix filename split delimiter and ext index

### DIFF
--- a/libaums/src/main/java/com/github/mjdev/libaums/fs/fat32/FatLfnDirectoryEntry.kt
+++ b/libaums/src/main/java/com/github/mjdev/libaums/fs/fat32/FatLfnDirectoryEntry.kt
@@ -93,10 +93,10 @@ internal class FatLfnDirectoryEntry
             var name = sname
             var ext = ""
 
-            val split = sname.split(".".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+            val split = sname.split("\\.".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
             if (split.size == 2) {
                 name = split[0]
-                ext = split[0]
+                ext = split[1]
             }
 
             if (actualEntry.isShortNameLowerCase)


### PR DESCRIPTION
"." regex matches any symbol, while "\\\\." matches only the dot - the actual delimiter in FAT32.
The "ext" part of the filename should be taken by index 1 from the split result.