### PR TITLE
Issue 332 - Priority control of FileSystemFactory creators

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/fs/FileSystemFactory.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/fs/FileSystemFactory.kt
@@ -33,9 +33,10 @@ import java.util.*
 object FileSystemFactory {
     private data class PrioritizedFileSystemCreator(val priority: Int, val count: Int, val creator: FileSystemCreator)
 
-    private var count = 0;
-    private val comparator = compareBy<PrioritizedFileSystemCreator> { it.priority }.thenBy { it.count }
-    private val fileSystems = ArrayList<PrioritizedFileSystemCreator>()
+    private var count = 0
+    private val fileSystems = TreeSet(
+        compareBy<PrioritizedFileSystemCreator> { it.priority }.thenBy { it.count }
+    )
 
     /**
      * The default priority of a creator registered with the file system.  Creators will be evaluated
@@ -63,7 +64,7 @@ object FileSystemFactory {
     @Throws(IOException::class, FileSystemFactory.UnsupportedFileSystemException::class)
     fun createFileSystem(entry: PartitionTableEntry,
                          blockDevice: BlockDeviceDriver): FileSystem {
-        fileSystems.sortedWith(comparator).forEach {
+        fileSystems.forEach {
             val fs = it.creator.read(entry, blockDevice)
             if (fs != null) {
                 return fs

--- a/libaums/src/main/java/me/jahnen/libaums/core/fs/FileSystemFactory.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/fs/FileSystemFactory.kt
@@ -44,13 +44,13 @@ object FileSystemFactory {
 
     class UnsupportedFileSystemException : IOException()
 
-    init {
-        registerFileSystem(Fat32FileSystemCreator())
-    }
-
     @Throws(IOException::class, FileSystemFactory.UnsupportedFileSystemException::class)
     fun createFileSystem(entry: PartitionTableEntry,
                          blockDevice: BlockDeviceDriver): FileSystem {
+        if(fileSystems.isEmpty()) {
+            registerFileSystem(Fat32FileSystemCreator())
+        }
+
         for (creator in fileSystems) {
             val fs = creator.read(entry, blockDevice)
             if (fs != null) {

--- a/libaums/src/test/java/me/jahnen/libaums/core/fs/FileSystemFactoryTest.java
+++ b/libaums/src/test/java/me/jahnen/libaums/core/fs/FileSystemFactoryTest.java
@@ -4,13 +4,16 @@ import me.jahnen.libaums.core.driver.BlockDeviceDriver;
 import me.jahnen.libaums.core.driver.ByteBlockDevice;
 import me.jahnen.libaums.core.driver.file.FileBlockDeviceDriver;
 import me.jahnen.libaums.core.fs.fat32.Fat32FileSystem;
+import me.jahnen.libaums.core.fs.fat32.Fat32FileSystemCreator;
 import me.jahnen.libaums.core.partition.PartitionTableEntry;
 import me.jahnen.libaums.core.partition.PartitionTypes;
 
 import org.junit.Test;
-
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -19,15 +22,56 @@ import static org.junit.Assert.assertTrue;
 public class FileSystemFactoryTest {
     @Test
     public void createFat32FileSystem() throws Exception {
-        BlockDeviceDriver blockDevice = new ByteBlockDevice(new FileBlockDeviceDriver(
-                new URL("https://www.dropbox.com/s/3bxngiqmwitlucd/mbr_fat32.img?dl=1"),
-                2 * 512));
-        blockDevice.init();
-
-        PartitionTableEntry entry = new PartitionTableEntry(PartitionTypes.FAT32, 2 * 512, 1337);
+        BlockDeviceDriver blockDevice = createDevice();
+        PartitionTableEntry entry = createPartitionTable();
         FileSystem fs = FileSystemFactory.INSTANCE.createFileSystem(entry, blockDevice);
 
         assertTrue(fs instanceof Fat32FileSystem);
     }
 
+    @Test
+    public void fileSystemPriority() throws Exception  {
+        ArrayList<String> orderTracker = new ArrayList<>();
+
+        // Clear and register with varying priorities to verify creators are invoked in expected order
+        FileSystemFactory.clearFileSystems();
+        FileSystemFactory.registerFileSystem(mockCreator(orderTracker,"not called"), FileSystemFactory.DEFAULT_PRIORITY + 4);
+        FileSystemFactory.registerFileSystem(mockCreator(orderTracker,"third"), FileSystemFactory.DEFAULT_PRIORITY + 1);
+        FileSystemFactory.registerFileSystem(mockCreator(orderTracker,"first"));
+        FileSystemFactory.registerFileSystem(mockCreator(orderTracker,"fourth"), FileSystemFactory.DEFAULT_PRIORITY + 2);
+        FileSystemFactory.registerFileSystem(mockCreator(orderTracker,"second"));
+        FileSystemFactory.registerFileSystem(new Fat32FileSystemCreator(), FileSystemFactory.DEFAULT_PRIORITY + 3);
+        FileSystemFactory.registerFileSystem(mockCreator(orderTracker,"not called"), FileSystemFactory.DEFAULT_PRIORITY + 5);
+
+        BlockDeviceDriver blockDevice = createDevice();
+        PartitionTableEntry entry = createPartitionTable();
+        FileSystem fs = FileSystemFactory.INSTANCE.createFileSystem(entry, blockDevice);
+
+        assertEquals(orderTracker, Arrays.asList("first", "second", "third", "fourth"));
+        assertTrue(fs instanceof Fat32FileSystem);
+
+        // Since this is a singleton try to return it to its original state for other tests
+        FileSystemFactory.clearFileSystems();
+        FileSystemFactory.registerFileSystem(new Fat32FileSystemCreator(), FileSystemFactory.DEFAULT_PRIORITY + 1);
+    }
+
+    private FileSystemCreator mockCreator(ArrayList<String> orderTracker, String name)  {
+        return (entry, blockDevice) -> {
+            orderTracker.add(name);
+            return null;
+        };
+    }
+
+    private BlockDeviceDriver createDevice() throws Exception {
+        BlockDeviceDriver blockDevice = new ByteBlockDevice(new FileBlockDeviceDriver(
+                new URL("https://www.dropbox.com/s/3bxngiqmwitlucd/mbr_fat32.img?dl=1"),
+                2 * 512));
+        blockDevice.init();
+
+        return blockDevice;
+    }
+
+    private PartitionTableEntry createPartitionTable() {
+        return new PartitionTableEntry(PartitionTypes.FAT32, 2 * 512, 1337);
+    }
 }


### PR DESCRIPTION
This approach allows for control which FileSystemCreator is evaluated first.  It may be considered a breaking change if anyone is depending on Fat32FileSystemCreator being registered automatically and also registering their own creators.