### PR TITLE
Fixing README.md at file.getLength() call

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ UsbFile root = currentFs.getRootDirectory();
 UsbFile[] files = root.listFiles();
 for(UsbFile file: files) {
     Log.d(TAG, file.getName());
-    if(file.isDirectory()) {
+    if(!file.isDirectory()) {
         Log.d(TAG, file.getLength());
     }
 }


### PR DESCRIPTION
The call to file.getLength() is only available for files, this makes sense as directories typically do not have a size.
I suppose the line is missing an exclamation mark (!) to invert the check if this is a directory. 
This change fixes the if check.