### PR TITLE
Reduce error recovery attempts

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
@@ -344,7 +344,7 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
     }
 
     companion object {
-        private const val MAX_RECOVERY_ATTEMPTS = 20
+        private const val MAX_RECOVERY_ATTEMPTS = 5
         private val TAG = ScsiBlockDevice::class.java.simpleName
     }
 }


### PR DESCRIPTION
When using the Android communication there's an internal timeout somewhere and each attempt takes over a second, causing the operation to fail after over 20s.

Also it doesn't appear like resuscitation works most time after more than a few retries, why did we set it so high?