### PR TITLE
Switch to more informative exceptions

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
@@ -25,7 +25,6 @@ import me.jahnen.libaums.core.driver.scsi.commands.sense.*
 import me.jahnen.libaums.core.usb.PipeException
 import me.jahnen.libaums.core.usb.UsbCommunication
 import java.io.IOException
-import java.lang.IllegalStateException
 import java.nio.ByteBuffer
 import java.util.*
 
@@ -78,19 +77,25 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
      */
     @Throws(IOException::class)
     override fun init() {
+        var lastException: Exception? = null
         for(i in 0..MAX_RECOVERY_ATTEMPTS) {
             try {
                 initAttempt()
                 return
-            } catch(e: InitRequired) {
+            } catch (e: InitRequired) {
                 Log.i(TAG, e.message ?: "Reinitializing device")
+                lastException = e
             } catch (e: NotReadyTryAgain) {
                 Log.i(TAG, e.message ?: "Reinitializing device")
+                lastException = e
             }
             Thread.sleep(100)
         }
 
-        throw IOException("MAX_RECOVERY_ATTEMPTS Exceeded while trying to init communication with USB device, please reattach device and try again")
+        throw IOException(
+            "MAX_RECOVERY_ATTEMPTS Exceeded while trying to init communication with USB device, please reattach device and try again",
+            lastException
+        )
     }
 
     @Throws(IOException::class)
@@ -143,6 +148,7 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
      */
     @Throws(IOException::class)
     private fun transferCommand(command: CommandBlockWrapper, inBuffer: ByteBuffer) {
+        var lastException: Exception? = null
         for(i in 0..MAX_RECOVERY_ATTEMPTS) {
             try {
                 val result = transferOneCommand(command, inBuffer)
@@ -167,18 +173,24 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
                     is NotReadyTryAgain -> {} // try again
                     else -> throw e
                 }
+                lastException = e
             } catch(e: PipeException) {
                 Log.w(TAG, (e.message ?: "PipeException") + ", try bulk storage reset and retry")
                 bulkOnlyMassStorageReset()
+                lastException = e
             } catch (e: IOException) {
                 // Retry
                 Log.w(TAG, (e.message ?: "IOException") + ", retrying...")
+                lastException = e
             }
 
             Thread.sleep(100)
         }
 
-        throw IOException("MAX_RECOVERY_ATTEMPTS Exceeded while trying to transfer command to device, please reattach device and try again")
+        throw IOException(
+            "MAX_RECOVERY_ATTEMPTS Exceeded while trying to transfer command to device, please reattach device and try again",
+            lastException
+        )
     }
 
     @Throws(IOException::class)

--- a/libusbcommunication/src/c/usb.c
+++ b/libusbcommunication/src/c/usb.c
@@ -6,7 +6,7 @@
 
 #define TAG "native_libusbcom"
 
-JNIEXPORT jboolean JNICALL
+JNIEXPORT jint JNICALL
 Java_me_jahnen_libaums_libusbcommunication_LibusbCommunication_nativeInit(JNIEnv *env, jobject thiz, jint fd, jlongArray handle) {
     LOG_D(TAG, "init native libusb");
     int ret;
@@ -18,25 +18,25 @@ Java_me_jahnen_libaums_libusbcommunication_LibusbCommunication_nativeInit(JNIEnv
     ret = libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY);
     if (ret != 0) {
         LOG_E(TAG, "libusb_set_option returned %d, %s", ret, libusb_strerror(ret));
-        return (jboolean) JNI_FALSE;
+        return ret;
     }
 #endif
 
     ret = libusb_init(NULL);
     if (ret != 0) {
         LOG_E(TAG, "libusb_init returned %d, %s", ret, libusb_strerror(ret));
-        return (jboolean) JNI_FALSE;
+        return ret;
     }
 
     libusb_device_handle *devh = NULL;
     ret = libusb_wrap_sys_device(NULL, fd, &devh);
     if (ret != 0) {
         LOG_E(TAG, "libusb_wrap_sys_device returned %d, %s", ret, libusb_strerror(ret));
-        return (jboolean) JNI_FALSE;
+        return ret;
     }
     if (devh == NULL) {
         LOG_E(TAG, "libusb_wrap_sys_device device handle, %s NULL", libusb_strerror(ret));
-        return (jboolean) JNI_FALSE;
+        return LIBUSB_ERROR_OTHER;
     }
 
     jlong *body = (*env)->GetLongArrayElements(env, handle, NULL);
@@ -44,7 +44,7 @@ Java_me_jahnen_libaums_libusbcommunication_LibusbCommunication_nativeInit(JNIEnv
     body[0] = (jlong)devh;
     (*env)->ReleaseLongArrayElements(env, handle, body, NULL);
 
-    return (jboolean) JNI_TRUE;
+    return 0;
 }
 
 JNIEXPORT void JNICALL

--- a/libusbcommunication/src/main/java/me/jahnen/libaums/libusbcommunication/ErrNoIOException.kt
+++ b/libusbcommunication/src/main/java/me/jahnen/libaums/libusbcommunication/ErrNoIOException.kt
@@ -1,0 +1,12 @@
+package me.jahnen.libaums.libusbcommunication
+
+import me.jahnen.libaums.core.ErrNo
+import java.io.IOException
+
+/**
+ * IOException that captures the errno and errstr of the current thread.
+ */
+open class ErrNoIOException(message: String, cause: Throwable? = null) : IOException(message, cause) {
+    val errno = ErrNo.errno
+    val errstr = ErrNo.errstr
+}

--- a/libusbcommunication/src/main/java/me/jahnen/libaums/libusbcommunication/LibusbError.kt
+++ b/libusbcommunication/src/main/java/me/jahnen/libaums/libusbcommunication/LibusbError.kt
@@ -1,0 +1,24 @@
+package me.jahnen.libaums.libusbcommunication
+
+enum class LibusbError(val code: Int, val message: String) {
+    SUCCESS(0, "Success (no error)"),
+    IO(-1, "Input/output error"),
+    INVALID_PARAM(-2, "Invalid parameter"),
+    ACCESS(-3, "Access denied (insufficient permissions)"),
+    NO_DEVICE(-4, "No such device (it may have been disconnected)"),
+    NOT_FOUND(-5, "Entity not found"),
+    BUSY(-6, "Resource busy"),
+    TIMEOUT(-7, "Operation timed out"),
+    OVERFLOW(-8, "Overflow"),
+    PIPE(-9, "Pipe error"),
+    INTERRUPTED(-10, "System call interrupted (perhaps due to signal)"),
+    NO_MEM(-11, "Insufficient memory"),
+    NOT_SUPPORTED(-12, "Operation not supported or unimplemented on this platform"),
+    OTHER(-99, "Other error");
+
+    companion object {
+        fun fromCode(code: Int): LibusbError {
+            return values().firstOrNull { it.code == code } ?: OTHER
+        }
+    }
+}

--- a/libusbcommunication/src/main/java/me/jahnen/libaums/libusbcommunication/LibusbException.kt
+++ b/libusbcommunication/src/main/java/me/jahnen/libaums/libusbcommunication/LibusbException.kt
@@ -1,0 +1,8 @@
+package me.jahnen.libaums.libusbcommunication
+
+open class LibusbException(
+    message: String,
+    val libusbError: LibusbError,
+    cause: Throwable? = null
+) :
+    ErrNoIOException("$message: ${libusbError.message} [${libusbError.code}]", cause)


### PR DESCRIPTION
This PR replaces the generic IOExceptions with richer children that carry the libusb return code and errno for any user that needs it up the stack as it is unwound.

This does not break any API since the new exceptions are all IOException children, but a few exception messages have changed.
