### PR TITLE
Fix/298

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
@@ -267,8 +267,7 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
         }
 
         var transferLength = command.dCbwDataTransferLength
-        inBuffer.clear()
-        inBuffer.limit(transferLength)
+        inBuffer.limit(inBuffer.position() + transferLength)
 
         var read = 0
         if (transferLength > 0) {
@@ -278,7 +277,7 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
                     read += usbCommunication.bulkInTransfer(inBuffer)
                     if (command.bCbwDynamicSize) {
                         transferLength = command.dynamicSizeFromPartialResponse(inBuffer)
-                        inBuffer.limit(transferLength)
+                        inBuffer.limit(inBuffer.position() + transferLength)
                     }
                 } while (read < transferLength)
 


### PR DESCRIPTION
Should be the same as https://github.com/tracmap/libaums/commit/7b9219106419142dec6b1a179067037a9e73c18d. But without creating a temporary buffer.
<img width="748" alt="Screenshot 2023-03-10 at 14 15 31" src="https://user-images.githubusercontent.com/1659457/224325433-ab9fff57-ac23-494f-9497-6949e92ebcfe.png">

Specifically we want to avoid calling clear here and instead use the position the buffer is that currently.

Addresses
* #298
* #341
* #353

